### PR TITLE
Gumbo v0.0

### DIFF
--- a/c3dev/galmocks/README.md
+++ b/c3dev/galmocks/README.md
@@ -1,3 +1,18 @@
 ## Mock Galaxy Challenge
 
 This sub-package contains source code used to make mock galaxy catalogs for the C3 Mock Challenge.
+
+### Installation
+
+To set up a typical working environment:
+
+$ conda create -n c3gmc python=3.9 numpy scipy matplotlib cython numba h5py astropy ipython jupyter halotools jax corrfunc pytest asdf pytest flake8
+$ conda activate c3gmc
+$ cd /path/to/c3dev
+$ python setup.py install
+
+If you want to create a jupyter kernel to use via https://jupyter.nersc.gov/, you will need to create and activate the environment as above, and then do:
+
+$ python -m ipykernel install —user —name c3gmc —display-name c3gmc_jkernel
+
+See https://docs.nersc.gov/services/jupyter/#conda-environments-as-kernels for further details about configuring a jupyter kernel on NERSC.

--- a/c3dev/galmocks/data_loaders/__init__.py
+++ b/c3dev/galmocks/data_loaders/__init__.py
@@ -1,0 +1,4 @@
+"""
+"""
+from .load_unit_sims import read_unit_sim
+from .load_gumbo import read_gumbo_mock

--- a/c3dev/galmocks/data_loaders/load_gumbo.py
+++ b/c3dev/galmocks/data_loaders/load_gumbo.py
@@ -1,0 +1,35 @@
+"""
+"""
+import os
+from astropy.table import Table
+
+
+NERSC_DRN = "/global/cfs/cdirs/desi/users/aphearin/C3GMC/gumbo"
+LATEST = "v0.0"
+
+
+def read_gumbo_mock(fn=None, drn=NERSC_DRN, version=LATEST):
+    """Read the gumbo mock from disk. Default is to load the latest version.
+
+    Parameters
+    ----------
+    fn : string, optional
+        Absolute path to a specific version of gumbo
+
+    version : string, optional
+        Version of gumbo to read. Default set by LATEST at top of module.
+
+    """
+    if fn is None:
+        bn = _get_gumbo_basename(version)
+        fn = os.path.join(drn, bn)
+
+    return Table.read(fn, path="data")
+
+
+def _get_gumbo_basename(version):
+    if version == "v0.0":
+        bn = "gumbo_v0.0.h5"
+    else:
+        raise ValueError("No other available versions of the gumbo mock")
+    return bn

--- a/c3dev/galmocks/data_loaders/load_tng_data.py
+++ b/c3dev/galmocks/data_loaders/load_tng_data.py
@@ -1,0 +1,13 @@
+"""
+"""
+
+
+SANDY_SCRATCH_PATH = "/global/cscratch1/sd/sihany/TNG300-1/output"
+BEBOP = "/lcrc/project/halotools/C3GMC/TNG300-1"
+
+
+def load_tng_subhalos(drn=SANDY_SCRATCH_PATH):
+    import illustris_python as il
+
+    subhalos = il.groupcat.loadSubhalos(drn, 55)
+    return subhalos

--- a/c3dev/galmocks/data_loaders/load_umachine.py
+++ b/c3dev/galmocks/data_loaders/load_umachine.py
@@ -1,0 +1,41 @@
+"""
+"""
+import numpy as np
+
+BEBOP_DRN = "/lcrc/project/halotools/C3GMC/UM/SMDPL/SFR_snapshot_binaries"
+BASENAME = "sfr_catalog_0.550400.bin"
+SMDPL_LBOX = 400.0  # Mpc/h
+
+DTYPE = np.dtype(
+    dtype=[
+        ("id", "i8"),
+        ("descid", "i8"),
+        ("upid", "i8"),
+        ("flags", "i4"),
+        ("uparent_dist", "f4"),
+        ("pos", "f4", (6)),
+        ("vmp", "f4"),
+        ("lvmp", "f4"),
+        ("mp", "f4"),
+        ("m", "f4"),
+        ("v", "f4"),
+        ("r", "f4"),
+        ("rank1", "f4"),
+        ("rank2", "f4"),
+        ("ra", "f4"),
+        ("rarank", "f4"),
+        ("A_UV", "f4"),
+        ("sm", "f4"),
+        ("icl", "f4"),
+        ("sfr", "i4"),
+        ("obs_sm", "f4"),
+        ("obs_sfr", "f4"),
+        ("obs_uv", "f4"),
+        ("empty", "f4"),
+    ],
+    align=True,
+)
+
+
+def read_sfr_snapshot(fn):
+    return np.fromfile(fn, dtype=DTYPE)

--- a/c3dev/galmocks/data_loaders/load_unit_sims.py
+++ b/c3dev/galmocks/data_loaders/load_unit_sims.py
@@ -1,0 +1,14 @@
+"""
+"""
+import os
+from astropy.table import Table
+
+
+TASSO = "/Users/aphearin/work/DATA/DESI/C3GMC/UNIT"
+BEBOP = "/lcrc/project/halotools/C3GMC/UNIT"
+EXAMPLE_BN = "out_107p.list.hdf5"
+UNIT_SIM_LBOX = 1000.0  # Mpc/h
+
+
+def read_unit_sim(fn):
+    return Table.read(os.path.join(fn), path="data")

--- a/c3dev/galmocks/scripts/make_gumbo.py
+++ b/c3dev/galmocks/scripts/make_gumbo.py
@@ -1,0 +1,180 @@
+"""
+"""
+import numpy as np
+import argparse
+from time import time
+from astropy.table import Table
+from c3dev.galmocks.data_loaders.load_umachine import DTYPE as UM_DTYPE
+from c3dev.galmocks.utils import galmatch
+from halotools.utils import crossmatch, sliding_conditional_percentile
+from halotools.empirical_models import noisy_percentile
+
+
+def compute_lg_ssfr(mstar, sfr, lgssfr_q=-11.8, low_ssfr_cut=1e-12):
+    raw_ssfr = sfr / mstar
+    ssfr_quenched = 10 ** np.random.normal(loc=lgssfr_q, scale=0.35, size=len(raw_ssfr))
+    ssfr = np.where(raw_ssfr < low_ssfr_cut, ssfr_quenched, raw_ssfr)
+    return np.log10(ssfr)
+
+
+UM_LOGSM_CUT = 9.0
+OUTPUT_LOGSM_CUT = 9.5
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("unit_sim_fn", help="path to unit sim subhalo catalog")
+    parser.add_argument("um_fn", help="path to um sfr catalog")
+    parser.add_argument("outname", help="Output fname")
+    args = parser.parse_args()
+
+    t0 = time()
+    um = Table(np.fromfile(args.um_fn, dtype=UM_DTYPE))
+    logsm_msk = um["sm"] > 10 ** UM_LOGSM_CUT
+    um = um[logsm_msk]
+    t1 = time()
+    unit = Table.read(args.unit_sim_fn, path="data")
+    t2 = time()
+    print("{0:.1f} seconds to load UM".format(t1 - t0))
+    print("{0:.1f} seconds to load UNIT".format(t2 - t1))
+
+    um["uber_host_indx"] = galmatch.compute_uber_host_indx(um["upid"], um["id"])
+    t3 = time()
+    unit["uber_host_indx"] = galmatch.compute_uber_host_indx(
+        unit["halo_upid"], unit["halo_id"]
+    )
+    t4 = time()
+    print("{0:.1f} seconds to compute UM hostid".format(t3 - t2))
+    print("{0:.1f} seconds to compute UNIT hostid".format(t4 - t3))
+
+    um["uber_host_haloid"] = um["id"][um["uber_host_indx"]]
+    um["mhost"] = um["m"][um["uber_host_indx"]]
+    um["rvir_host"] = um["r"][um["uber_host_indx"]] / 1000.0
+    um["uber_host_pos"] = um["pos"][um["uber_host_indx"]]
+    um["host_delta_pos"] = um["pos"] - um["uber_host_pos"]
+
+    unit["uber_host_haloid"] = unit["halo_id"][unit["uber_host_indx"]]
+
+    cenmsk_um = um["uber_host_haloid"] == um["id"]
+    cenmsk_unit = unit["uber_host_haloid"] == unit["halo_id"]
+
+    source_galaxies_host_halo_id = um["uber_host_haloid"]
+    source_halo_ids = um["id"][cenmsk_um]
+    target_halo_ids = unit["halo_id"][cenmsk_unit]
+    source_halo_props = (np.log10(um["m"][cenmsk_um]),)
+    target_halo_props = (np.log10(unit["halo_mvir"][cenmsk_unit]),)
+    d = (
+        source_galaxies_host_halo_id,
+        source_halo_ids,
+        target_halo_ids,
+        source_halo_props,
+        target_halo_props,
+    )
+    t5 = time()
+    galsampler_res = galmatch.compute_source_galaxy_selection_indices(*d)
+    t6 = time()
+    print("{0:.1f} seconds to galsample".format(t6 - t5))
+
+    # Inherit from UNIT
+    keys_to_inherit_from_unit = (
+        "halo_x",
+        "halo_y",
+        "halo_z",
+        "halo_vx",
+        "halo_vy",
+        "halo_vz",
+        "halo_mvir",
+        "halo_rvir",
+    )
+    n_output_mock = galsampler_res.target_gals_target_halo_ids.size
+    idxA, idxB = crossmatch(galsampler_res.target_gals_target_halo_ids, unit["halo_id"])
+    output_mock = Table()
+    for key in keys_to_inherit_from_unit:
+        output_mock["unit_" + key] = np.zeros(n_output_mock)
+        output_mock["unit_" + key][idxA] = unit[key][idxB]
+    t7 = time()
+    print("{0:.1f} seconds to inherit from unit with crossmatch".format(t7 - t6))
+
+    # Inherit from UM
+    keys_to_inherit_from_um = (
+        "m",
+        "sm",
+        "sfr",
+        "uber_host_haloid",
+        "id",
+        "mhost",
+        "rvir_host",
+        "host_delta_pos",
+    )
+    for key in keys_to_inherit_from_um:
+        output_mock["um_" + key] = um[key][galsampler_res.target_gals_selection_indx]
+    output_mock[
+        "galsampler_target_halo_ids"
+    ] = galsampler_res.target_gals_target_halo_ids
+    output_mock[
+        "galsampler_source_halo_ids"
+    ] = galsampler_res.target_gals_source_halo_ids
+    t8 = time()
+    print("{0:.1f} seconds to inherit from UM".format(t8 - t7))
+
+    tng_phot_sample_fn = "/lcrc/project/halotools/C3GMC/TNG300-1/tng_phot_sample.h5"
+    tng_phot_sample = Table.read(tng_phot_sample_fn, path="data")
+    tng_phot_sample["logsm"] = np.log10(tng_phot_sample["SubhaloMassType"][:, 4]) + 10
+
+    output_mock["um_logsm"] = np.log10(output_mock["um_sm"])
+
+    output_mock["lgssfr"] = compute_lg_ssfr(
+        10 ** output_mock["um_logsm"], output_mock["um_sfr"] / 1e9
+    )
+    tng_phot_sample["lgssfr"] = compute_lg_ssfr(
+        10 ** tng_phot_sample["logsm"], tng_phot_sample["SubhaloSFR"]
+    )
+
+    output_mock["lgssfr_perc"] = sliding_conditional_percentile(
+        output_mock["um_logsm"], output_mock["lgssfr"], 201
+    )
+    tng_phot_sample["lgssfr_perc"] = sliding_conditional_percentile(
+        tng_phot_sample["logsm"], tng_phot_sample["lgssfr"], 201
+    )
+    output_mock["lgssfr_perc_noisy"] = noisy_percentile(output_mock["lgssfr_perc"], 0.9)
+
+    source_props = (tng_phot_sample["logsm"], tng_phot_sample["lgssfr_perc"])
+    target_props = (output_mock["um_logsm"], output_mock["lgssfr_perc_noisy"])
+
+    dd_match, indx_match = galmatch.calculate_indx_correspondence(
+        source_props, target_props
+    )
+    output_mock["tng_logsm"] = tng_phot_sample["logsm"][indx_match]
+    output_mock["tng_lgssfr"] = tng_phot_sample["lgssfr"][indx_match]
+    output_mock["tng_grizy"] = tng_phot_sample["grizy"][indx_match]
+    t9 = time()
+    print("{0:.1f} seconds to inherit from TNG".format(t9 - t8))
+
+    # Assign positions
+    rhalo_ratio = output_mock["unit_halo_rvir"] * output_mock["um_rvir_host"]
+    dx = output_mock["um_host_delta_pos"][:, 0] * rhalo_ratio
+    dy = output_mock["um_host_delta_pos"][:, 1] * rhalo_ratio
+    dz = output_mock["um_host_delta_pos"][:, 2] * rhalo_ratio
+
+    output_mock["galaxy_x"] = output_mock["unit_halo_x"] + dx
+    output_mock["galaxy_y"] = output_mock["unit_halo_y"] + dy
+    output_mock["galaxy_z"] = output_mock["unit_halo_z"] + dz
+
+    output_mock["galaxy_vx"] = (
+        output_mock["unit_halo_vx"] + output_mock["um_host_delta_pos"][:, 3]
+    )
+    output_mock["galaxy_vy"] = (
+        output_mock["unit_halo_vy"] + output_mock["um_host_delta_pos"][:, 4]
+    )
+    output_mock["galaxy_vz"] = (
+        output_mock["unit_halo_vz"] + output_mock["um_host_delta_pos"][:, 5]
+    )
+
+    # Reduce mock size
+    output_cut_msk = output_mock["um_logsm"] > OUTPUT_LOGSM_CUT
+    output_mock = output_mock[output_cut_msk]
+
+    # Write to disk
+    output_mock.write(args.outname, path="data")
+
+    t10 = time()
+    print("{0:.1f} seconds total runtime".format(t10 - t0))

--- a/c3dev/galmocks/scripts/make_gumbo_v0.0.py
+++ b/c3dev/galmocks/scripts/make_gumbo_v0.0.py
@@ -1,4 +1,4 @@
-"""
+"""Production script for gumbo_v0.0
 """
 import numpy as np
 import argparse

--- a/c3dev/galmocks/utils/galmatch.py
+++ b/c3dev/galmocks/utils/galmatch.py
@@ -1,0 +1,281 @@
+"""
+"""
+from warnings import warn
+import numpy as np
+from scipy.spatial import cKDTree
+from halotools.utils import crossmatch, compute_richness
+from numba import njit
+from collections import namedtuple
+
+GalsamplerCorrespondence = namedtuple(
+    "GalsamplerCorrespondence",
+    [
+        "target_gals_selection_indx",
+        "target_gals_target_halo_ids",
+        "target_gals_source_halo_ids",
+    ],
+)
+
+__all__ = ("compute_source_galaxy_selection_indices",)
+
+
+@njit
+def galaxy_selection_kernel(first_source_gal_indices, richness, n_target_halo, result):
+    """Numba kernel filling in array of galaxy selection indices
+
+    Parameters
+    ----------
+    first_source_gal_indices : ndarray of shape (n_target_halo, )
+        Stores the index of the first galaxy in the galaxy catalog
+        assigned to each target halo
+
+    richness : ndarray of shape (n_target_halo, )
+        Stores the number of galaxies that will be mapped to each target halo
+
+    n_target_halo : int
+
+    result : ndarray of shape richness.sum()
+
+    """
+    cur = 0
+    for i in range(n_target_halo):
+        ifirst = first_source_gal_indices[i]
+        n = richness[i]
+        if n > 0:
+            ilast = ifirst + richness[i]
+            for j in range(ifirst, ilast):
+                result[cur] = j
+                cur += 1
+
+
+def _get_data_block(*halo_properties):
+    return np.vstack(halo_properties).T
+
+
+def calculate_halo_correspondence(source_halo_props, target_halo_props, n_threads=-1):
+    """Calculating indexing array defined by a statistical correspondence between
+    source and target halos.
+
+    Parameters
+    ----------
+    source_halo_props : sequence of n_props ndarrays
+        Each ndarray should have shape (n_source_halos, )
+
+    target_halo_props : sequence of n_props ndarrays
+        Each ndarray should have shape (n_target_halos, )
+
+    Returns
+    -------
+    dd_match : ndarray of shape (n_target_halos, )
+        Euclidean distance to the source halo matched to each target halo
+
+    indx_match : ndarray of shape (n_target_halos, )
+        Index of the source halo matched to each target halo
+
+    """
+    assert len(source_halo_props) == len(target_halo_props)
+    X_source = _get_data_block(*source_halo_props)
+    X_target = _get_data_block(*target_halo_props)
+    source_tree = cKDTree(X_source)
+    dd_match, indx_match = source_tree.query(X_target, workers=n_threads)
+    return dd_match, indx_match
+
+
+def compute_source_galaxy_selection_indices(
+    source_galaxies_host_halo_id,
+    source_halo_ids,
+    target_halo_ids,
+    source_halo_props,
+    target_halo_props,
+):
+    """Calculate the indexing array that transfers source galaxies to target halos
+
+    Parameters
+    ----------
+    source_galaxies_host_halo_id : ndarray of shape (n_source_gals, )
+        Integer array storing values appearing in source_halo_ids
+
+    source_halo_ids : ndarray of shape (n_source_halos, )
+
+    target_halo_ids : ndarray of shape (n_target_halos, )
+
+    source_halo_props : sequence of n_props ndarrays
+        Each ndarray should have shape (n_source_halos, )
+
+    target_halo_props : sequence of n_props ndarrays
+        Each ndarray should have shape (n_target_halos, )
+
+    Returns
+    -------
+    selection_indices : ndarray of shape (n_target_gals, )
+        Integer array storing values in the range [0, n_source_gals-1]
+
+    target_galaxy_target_halo_ids : ndarray of shape (n_target_gals, )
+        Integer array storing values appearing in target_halo_ids
+
+    target_galaxy_source_halo_ids : ndarray of shape (n_target_gals, )
+        Integer array storing values appearing in source_halo_ids
+
+    """
+    #  Sort the source galaxies so that members of a common halo are grouped together
+    idx_sorted_source_galaxies = np.argsort(source_galaxies_host_halo_id)
+    sorted_source_galaxies_host_halo_id = source_galaxies_host_halo_id[
+        idx_sorted_source_galaxies
+    ]
+
+    #  Calculate the index correspondence array that will undo the sorting at the end
+    num_source_gals = len(source_galaxies_host_halo_id)
+    idx_unsorted_galaxy_indices = np.arange(num_source_gals).astype("i8")[
+        idx_sorted_source_galaxies
+    ]
+
+    #  For each source halo, calculate the number of resident galaxies
+    source_halos_richness = compute_richness(
+        source_halo_ids, sorted_source_galaxies_host_halo_id
+    )
+
+    #  For each source halo, calculate the index of its first resident galaxy
+    source_halo_sorted_source_galaxies_indices = _galaxy_table_indices(
+        source_halo_ids, sorted_source_galaxies_host_halo_id
+    )
+
+    #  For each target halo, calculate the index of the associated source halo
+    __, source_halo_selection_indices = calculate_halo_correspondence(
+        source_halo_props, target_halo_props
+    )
+
+    #  For each target halo, calculate the number of galaxies
+    target_halo_richness = source_halos_richness[source_halo_selection_indices]
+    num_target_gals = np.sum(target_halo_richness)
+
+    #  For each target halo, calculate the halo ID of the associated source halo
+    target_halo_source_halo_ids = source_halo_ids[source_halo_selection_indices]
+
+    #  For each target halo, calculate the index of its first resident galaxy
+    target_halo_first_sorted_source_gal_indices = (
+        source_halo_sorted_source_galaxies_indices[source_halo_selection_indices]
+    )
+
+    #  For every target halo, we know the index of the first and last galaxy to select
+    #  Calculate an array of shape (num_target_gals, )
+    # with the index of each selected galaxy
+    n_target_halos = target_halo_ids.size
+    sorted_source_galaxy_selection_indices = np.zeros(num_target_gals).astype(int)
+    galaxy_selection_kernel(
+        target_halo_first_sorted_source_gal_indices.astype("i8"),
+        target_halo_richness.astype("i4"),
+        n_target_halos,
+        sorted_source_galaxy_selection_indices,
+    )
+
+    #  For each target galaxy, calculate the halo ID of its source and target halo
+    target_gals_target_halo_ids = np.repeat(target_halo_ids, target_halo_richness)
+    target_gals_source_halo_ids = np.repeat(
+        target_halo_source_halo_ids, target_halo_richness
+    )
+
+    #  For each index in the sorted galaxy catalog,
+    #  calculate the index of the catalog in its original order
+    target_gals_selection_indx = idx_unsorted_galaxy_indices[
+        sorted_source_galaxy_selection_indices
+    ]
+
+    return GalsamplerCorrespondence(
+        target_gals_selection_indx,
+        target_gals_target_halo_ids,
+        target_gals_source_halo_ids,
+    )
+
+
+def _galaxy_table_indices(source_halo_id, galaxy_host_halo_id):
+    """For every halo in the source halo catalog, calculate the index
+    in the source galaxy catalog of the first appearance of a galaxy that
+    occupies the halo, reserving -1 for source halos with no resident galaxies.
+
+    Parameters
+    ----------
+    source_halo_id : ndarray
+        Numpy integer array of shape (num_halos, )
+
+    galaxy_host_halo_id : ndarray
+        Numpy integer array of shape (num_gals, )
+
+    Returns
+    -------
+    indices : ndarray
+        Numpy integer array of shape (num_halos, ).
+        All values will be in the interval [-1, num_gals)
+    """
+    uval_gals, indx_uval_gals = np.unique(galaxy_host_halo_id, return_index=True)
+    idxA, idxB = crossmatch(source_halo_id, uval_gals)
+    num_source_halos = len(source_halo_id)
+    indices = np.zeros(num_source_halos) - 1
+    indices[idxA] = indx_uval_gals[idxB]
+    return indices.astype(int)
+
+
+def compute_hostid(upid, haloid):
+    cenmsk = upid == -1
+    hostid = np.copy(haloid)
+    hostid[~cenmsk] = upid[~cenmsk]
+    idxA, idxB = crossmatch(hostid, haloid)
+
+    has_match = np.zeros(haloid.size).astype("bool")
+    has_match[idxA] = True
+    hostid[~has_match] = haloid[~has_match]
+    return hostid, idxA, idxB, has_match
+
+
+def compute_uber_host_indx(
+    upid, haloid, max_order=20, fill_val=-99, return_internals=False
+):
+    hostid, idxA, idxB, has_match = compute_hostid(upid, haloid)
+    cenmsk = hostid == haloid
+
+    if len(idxA) != len(haloid):
+        msg = "{0} values of upid have no match. Treating these objects as centrals"
+        warn(msg.format(len(haloid) - len(idxA)))
+
+    _integers = np.arange(haloid.size).astype(int)
+    uber_host_indx = np.zeros_like(haloid) + fill_val
+    uber_host_indx[cenmsk] = _integers[cenmsk]
+
+    n_unmatched = np.count_nonzero(uber_host_indx == fill_val)
+    counter = 0
+    while (n_unmatched > 0) and (counter < max_order):
+        uber_host_indx[idxA] = uber_host_indx[idxB]
+        n_unmatched = np.count_nonzero(uber_host_indx == fill_val)
+        counter += 1
+
+    if return_internals:
+        return uber_host_indx, idxA, idxB
+    else:
+        return uber_host_indx
+
+
+def calculate_indx_correspondence(source_props, target_props, n_threads=-1):
+    """For each target data object, find a closely matching source data object
+
+    Parameters
+    ----------
+    source_props : list of n_props ndarrays
+        Each ndarray should have shape (n_source, )
+
+    target_props : list of n_props ndarrays
+        Each ndarray should have shape (n_target, )
+
+    Returns
+    -------
+    dd_match : ndarray of shape (n_target, )
+        Euclidean distance between each target and its matching source object
+
+    indx_match : ndarray of shape (n_target, )
+        Index into the source object that is matched to each target
+
+    """
+    assert len(source_props) == len(target_props)
+    X_source = _get_data_block(*source_props)
+    X_target = _get_data_block(*target_props)
+    source_tree = cKDTree(X_source)
+    dd_match, indx_match = source_tree.query(X_target, workers=n_threads)
+    return dd_match, indx_match


### PR DESCRIPTION
This PR brings in code to generate and read the **gumbo_v0.0** mock. Briefly, I've adapted the methods in [the GalSampler paper](https://arxiv.org/abs/1909.07340) to populate host halos in the UNIT sim with a UniverseMachine-like galaxy catalog with stellar masses and SFR, and then augmented the galaxy properties based on TNG galaxies.

## Loading the mock
To load this mock into memory from NERSC:

```
>>> from c3dev.galmocks.data_loaders import read_gumbo_mock
>>> mock = read_gumbo_mock()
```
The path storing the data and associated README are here:
/global/cfs/cdirs/desi/users/aphearin/C3GMC/gumbo/

## Notes on methodology
* For each host halo in UNIT, find a host halo in UM with a closely matching mvir
* Transfer the entire galaxy content of the UM halo into the UNIT halo, preserving host-centric pos/vel
* Calculate p_sfr := P(<lgssfr | Mstar) of the UM galaxies
* For each UM galaxy, find a TNG galaxy with closely matching logsm and p_sfr
* Transfer the photometry of the matching TNG galaxy to its UM counterpart

## Plots of basic occupation statistics
![gumbo_v0 0_xy](https://user-images.githubusercontent.com/6951595/152546682-d6d0149a-1720-4d5d-9e16-b55d53f6c1ea.png)
![gumbo_v0 0_smhm](https://user-images.githubusercontent.com/6951595/152546726-49e1a722-b4f4-4b04-94f7-a7ca82ddc1d2.png)
![gumbo_v0 0_ssfr](https://user-images.githubusercontent.com/6951595/152546751-99f1cb66-2537-4a2c-81cf-1aa10140f5d6.png)
![gumbo_v0 0_richness](https://user-images.githubusercontent.com/6951595/152547175-816ed88f-dd23-459d-8f17-2f0345ce1f3f.png)
![gumbo_v0 0_color_pdfs](https://user-images.githubusercontent.com/6951595/152546790-03c2fc80-bede-421c-a970-0d70a9be1cd1.png)

