### PR TITLE
Switch c3gmc --> c3emc

### DIFF
--- a/c3dev/galmocks/README.md
+++ b/c3dev/galmocks/README.md
@@ -6,13 +6,13 @@ This sub-package contains source code used to make mock galaxy catalogs for the 
 
 To set up a typical working environment:
 
-$ conda create -n c3gmc python=3.9 numpy scipy matplotlib cython numba h5py astropy ipython jupyter halotools jax corrfunc pytest asdf pytest flake8
-$ conda activate c3gmc
+$ conda create -n c3emc python=3.9 numpy scipy matplotlib cython numba h5py astropy ipython jupyter halotools jax corrfunc pytest asdf pytest flake8
+$ conda activate c3emc
 $ cd /path/to/c3dev
 $ python setup.py install
 
 If you want to create a jupyter kernel to use via https://jupyter.nersc.gov/, you will need to create and activate the environment as above, and then do:
 
-$ python -m ipykernel install —user —name c3gmc —display-name c3gmc_jkernel
+$ python -m ipykernel install —user —name c3emc —display-name c3emc_jkernel
 
 See https://docs.nersc.gov/services/jupyter/#conda-environments-as-kernels for further details about configuring a jupyter kernel on NERSC.

--- a/c3dev/galmocks/data_loaders/load_gumbo.py
+++ b/c3dev/galmocks/data_loaders/load_gumbo.py
@@ -4,7 +4,7 @@ import os
 from astropy.table import Table
 
 
-NERSC_DRN = "/global/cfs/cdirs/desi/users/aphearin/C3GMC/gumbo"
+NERSC_DRN = "/global/cfs/cdirs/desi/users/aphearin/C3EMC/gumbo"
 LATEST = "v0.0"
 
 

--- a/c3dev/galmocks/data_loaders/load_tng_data.py
+++ b/c3dev/galmocks/data_loaders/load_tng_data.py
@@ -3,7 +3,7 @@
 
 
 SANDY_SCRATCH_PATH = "/global/cscratch1/sd/sihany/TNG300-1/output"
-BEBOP = "/lcrc/project/halotools/C3GMC/TNG300-1"
+BEBOP = "/lcrc/project/halotools/C3EMC/TNG300-1"
 
 
 def load_tng_subhalos(drn=SANDY_SCRATCH_PATH):

--- a/c3dev/galmocks/data_loaders/load_umachine.py
+++ b/c3dev/galmocks/data_loaders/load_umachine.py
@@ -2,7 +2,7 @@
 """
 import numpy as np
 
-BEBOP_DRN = "/lcrc/project/halotools/C3GMC/UM/SMDPL/SFR_snapshot_binaries"
+BEBOP_DRN = "/lcrc/project/halotools/C3EMC/UM/SMDPL/SFR_snapshot_binaries"
 BASENAME = "sfr_catalog_0.550400.bin"
 SMDPL_LBOX = 400.0  # Mpc/h
 

--- a/c3dev/galmocks/data_loaders/load_unit_sims.py
+++ b/c3dev/galmocks/data_loaders/load_unit_sims.py
@@ -4,8 +4,8 @@ import os
 from astropy.table import Table
 
 
-TASSO = "/Users/aphearin/work/DATA/DESI/C3GMC/UNIT"
-BEBOP = "/lcrc/project/halotools/C3GMC/UNIT"
+TASSO = "/Users/aphearin/work/DATA/DESI/C3EMC/UNIT"
+BEBOP = "/lcrc/project/halotools/C3EMC/UNIT"
 EXAMPLE_BN = "out_107p.list.hdf5"
 UNIT_SIM_LBOX = 1000.0  # Mpc/h
 

--- a/c3dev/galmocks/scripts/make_gumbo_v0.0.py
+++ b/c3dev/galmocks/scripts/make_gumbo_v0.0.py
@@ -116,7 +116,7 @@ if __name__ == "__main__":
     t8 = time()
     print("{0:.1f} seconds to inherit from UM".format(t8 - t7))
 
-    tng_phot_sample_fn = "/lcrc/project/halotools/C3GMC/TNG300-1/tng_phot_sample.h5"
+    tng_phot_sample_fn = "/lcrc/project/halotools/C3EMC/TNG300-1/tng_phot_sample.h5"
     tng_phot_sample = Table.read(tng_phot_sample_fn, path="data")
     tng_phot_sample["logsm"] = np.log10(tng_phot_sample["SubhaloMassType"][:, 4]) + 10
 


### PR DESCRIPTION
This PR implements a name change requested by @alexieleauthaud. All references to the acronym "C3GMC" have been replaced with "C3EMC". This includes the default arguments for the paths of the data loaders within the galmocks code base, and also the corresponding paths on NERSC where the data have actually been written to disk.