### PR TITLE
Gumbo v0p2

### DIFF
--- a/c3dev/galmocks/data_loaders/load_gumbo.py
+++ b/c3dev/galmocks/data_loaders/load_gumbo.py
@@ -5,7 +5,7 @@ from astropy.table import Table
 
 
 NERSC_DRN = "/global/cfs/cdirs/desi/users/aphearin/C3EMC/gumbo"
-LATEST = "v0.1"
+LATEST = "v0.2"
 
 
 def read_gumbo_mock(fn=None, drn=NERSC_DRN, version=LATEST):
@@ -32,6 +32,8 @@ def _get_gumbo_basename(version):
         bn = "gumbo_v0.0.h5"
     elif version == "v0.1":
         bn = "gumbo_v0.1.h5"
+    elif version == "v0.2":
+        bn = "gumbo_v0.2.h5"
     else:
         raise ValueError("No other available versions of the gumbo mock")
     return bn

--- a/c3dev/galmocks/data_loaders/load_unit_sims.py
+++ b/c3dev/galmocks/data_loaders/load_unit_sims.py
@@ -6,7 +6,7 @@ from ..utils.galmatch import compute_uber_host_indx
 
 
 TASSO = "/Users/aphearin/work/DATA/DESI/C3EMC/UNIT"
-BEBOP = "/lcrc/project/halotools/C3EMC/UNIT"
+BEBOP = "/lcrc/project/halotools/C3EMC/UNIT/v0.2"
 NERSC = "/global/cfs/cdirs/desi/users/aphearin/C3EMC/UNIT"
 BN = "out_107p.list.hdf5"
 UNIT_LBOX = 1000.0  # Mpc/h


### PR DESCRIPTION
This PR updates the data loader of the gumbo mocks to v0.2, which is now up on NERSC.

Here are a few quick diagnostic plots of the mock, which populates host halos at z=0.6 of the UNIT simulation.

Here's a visual check that galaxy positions (in a subvolume) trace the cosmic web, with galaxies in massive halos living mostly in nodes and filaments.
![gumbo_v0 2_web](https://user-images.githubusercontent.com/6951595/177425556-e73bad39-86ea-4276-b1a6-fe7e783b6e48.png)
 
The stellar mass function looks broadly reasonable:
![gumbo_v0 2_smf](https://user-images.githubusercontent.com/6951595/177425658-24588501-28e8-425a-97ca-afe30085ca8c.png)

The HODs have a reasonable shape and expected dependence upon stellar mass threshold:
![gumbo_v0 2_hod](https://user-images.githubusercontent.com/6951595/177425986-317f0c30-e9f1-4303-965f-4847cd647f20.png)

## intra-halo positions and velocities
There are four different variations of the galaxy positions in v0.2. Briefly, these models are:
1. Host-centric pos/vel is lifted directly from TNG galaxy/halo and added directly to UNIT halo pos/vel
2.  Host-centric pos/vel comes from ellipsoidal NFW model, with major axis aligned with shape eigenvector of the UNIT halo
3.  Host-centric pos/vel comes from ellipsoidal NFW model, with randomly aligned major axis
4.  Host-centric pos/vel comes from spherical NFW model, using concentration of the UNIT halo
This scatter plot is in the halo eigenframe, with the x-axis aligned with the halo orientation. You can see that in the LSS-correlated model, the host-centric positions of satellites are stretched out along the direction of the halo orientation. The only difference in the LSS-uncorrelated model is that a random orientation is used instead of the halo orientation

![gumbo_v0 2_satpos](https://user-images.githubusercontent.com/6951595/177426043-bc98f094-cbcc-43c5-9e2c-c5f34e555bde.png)


